### PR TITLE
Change JSON database column to binary

### DIFF
--- a/src/database/migrations/2017_05_22_160000_create_settings_lists_table.php
+++ b/src/database/migrations/2017_05_22_160000_create_settings_lists_table.php
@@ -19,7 +19,7 @@ class CreateSettingsListsTable extends Migration
 		Schema::create('settings__lists', function (Blueprint $table)
 		{
 			$table->string('setting_key')->index()->unique();
-			$table->json('setting_value')->nullable();
+			$table->binary('setting_value')->nullable();
 		});
 	}
 


### PR DESCRIPTION
When using certain databases with certain character sets & collations, we are unable to create JSON columns, however a binary column is perfectly fine in this instance.